### PR TITLE
Fix imports for direct script execution

### DIFF
--- a/ultimate_agent/core/__init__.py
+++ b/ultimate_agent/core/__init__.py
@@ -1,1 +1,11 @@
-"""Package initialization."""
+"""Core package initialization.
+
+This module exposes the most commonly used classes from the core package so
+they can be imported directly from :mod:`ultimate_agent.core`.
+"""
+
+from .agent import UltimateAgent
+from .container import Container
+from .events import event_bus
+
+__all__ = ["UltimateAgent", "Container", "event_bus"]

--- a/ultimate_agent/core/agent.py
+++ b/ultimate_agent/core/agent.py
@@ -1,9 +1,17 @@
 import asyncio
-from ultimate_agent.config.settings import settings
-from ultimate_agent.core.container import Container
-from ultimate_agent.tasks.execution.scheduler import TaskScheduler
-from ultimate_agent.remote.handler import RemoteCommandHandler  # ✅ use the actual file
-from ultimate_agent.core.events import event_bus
+
+try:
+    from ..config.settings import settings
+    from .container import Container
+    from ..tasks.execution.scheduler import TaskScheduler
+    from ..remote.handler import RemoteCommandHandler  # ✅ use the actual file
+    from .events import event_bus
+except ImportError:  # pragma: no cover - allow running module standalone
+    from ultimate_agent.config.settings import settings  # type: ignore
+    from ultimate_agent.core.container import Container  # type: ignore
+    from ultimate_agent.tasks.execution.scheduler import TaskScheduler  # type: ignore
+    from ultimate_agent.remote.handler import RemoteCommandHandler  # type: ignore
+    from ultimate_agent.core.events import event_bus  # type: ignore
 
 class UltimateAgent:
     def __init__(self):

--- a/ultimate_agent/core/container.py
+++ b/ultimate_agent/core/container.py
@@ -22,7 +22,10 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for minimal envs
                     self._instance = self.cls(*self.args, **self.kwargs)
                 return self._instance
 
-from ultimate_agent.config.settings import settings
+try:
+    from ..config.settings import settings
+except ImportError:  # pragma: no cover - allow running module standalone
+    from ultimate_agent.config.settings import settings  # type: ignore
 
 class Container(containers.DeclarativeContainer):
     config = providers.Configuration()

--- a/ultimate_agent/remote/handler.py
+++ b/ultimate_agent/remote/handler.py
@@ -1,6 +1,9 @@
 from typing import Any, Callable, Dict
 
-from ultimate_agent.core.events import event_bus
+try:
+    from ..core.events import event_bus
+except ImportError:  # pragma: no cover - allow running module standalone
+    from ultimate_agent.core.events import event_bus  # type: ignore
 
 
 class RemoteCommandHandler:

--- a/ultimate_agent/tasks/execution/executor.py
+++ b/ultimate_agent/tasks/execution/executor.py
@@ -1,6 +1,11 @@
 import time
-from ultimate_agent.core.events import event_bus
-from ultimate_agent.config.settings import settings
+
+try:
+    from ...core.events import event_bus
+    from ...config.settings import settings
+except ImportError:  # pragma: no cover - allow running module standalone
+    from ultimate_agent.core.events import event_bus  # type: ignore
+    from ultimate_agent.config.settings import settings  # type: ignore
 
 class TaskExecutor:
     def __init__(self):

--- a/ultimate_agent/tasks/execution/scheduler.py
+++ b/ultimate_agent/tasks/execution/scheduler.py
@@ -5,8 +5,12 @@ try:
     import aioredis  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - fallback for tests
     aioredis = None
-from ultimate_agent.tasks.execution.executor import TaskExecutor
-from ultimate_agent.config.settings import settings
+try:
+    from .executor import TaskExecutor
+    from ...config.settings import settings
+except ImportError:  # pragma: no cover - allow running module standalone
+    from ultimate_agent.tasks.execution.executor import TaskExecutor  # type: ignore
+    from ultimate_agent.config.settings import settings  # type: ignore
 
 class TaskScheduler:
     def __init__(self):
@@ -63,7 +67,7 @@ class TaskScheduler:
                     print(f"📨 Redis Control Message: {data}")
                     import json
                     command = json.loads(data)
-                    from ultimate_agent.core.events import event_bus
+                    from ...core.events import event_bus
                     event_bus.publish("remote.command", command)
                 except Exception as e:
                     print(f"❌ Failed to process control message: {e}")


### PR DESCRIPTION
## Summary
- fall back to absolute imports so modules can be run without package context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d2b6c0748328bc4de20ddeb74e8e