### PR TITLE
Fix imports for enhanced_node

### DIFF
--- a/enhanced_node/main.py
+++ b/enhanced_node/main.py
@@ -10,16 +10,19 @@ import os
 from pathlib import Path
 
 # Add current directory to path for imports
-current_dir = Path(__file__).parent
-sys.path.insert(0, str(current_dir))
+current_dir = Path(__file__).resolve().parent
+# Ensure package imports work when running as a script
+if __package__ in (None, ""):
+    sys.path.insert(0, str(current_dir.parent))
+    __package__ = current_dir.name
 
 # Import modular components
 try:
-    from core.server import EnhancedNodeServer
-    from routes.api_v3 import register_api_v3_routes
-    from routes.api_v5_remote import register_api_v5_routes
-    from websocket.events import register_websocket_events
-    from config.settings import NODE_PORT, NODE_VERSION, NODE_ID
+    from .core.server import EnhancedNodeServer
+    from .routes.api_v3 import register_api_v3_routes
+    from .routes.api_v5_remote import register_api_v5_routes
+    from .websocket.events import register_websocket_events
+    from .config.settings import NODE_PORT, NODE_VERSION, NODE_ID
 except ImportError as e:
     print(f"❌ Import Error: {e}")
     print("   Please ensure you're running from the enhanced_node/ directory")

--- a/enhanced_node/readme_file.md
+++ b/enhanced_node/readme_file.md
@@ -104,14 +104,14 @@ pip install --upgrade pip
 pip install -r requirements.txt
 
 # Run the server
-python main.py
+python -m enhanced_node.main
 ```
 
 ### Method 3: Direct Execution
 
 ```bash
 # If you have all dependencies installed
-python main.py
+python -m enhanced_node.main
 ```
 
 ## 🌐 Access Points


### PR DESCRIPTION
## Summary
- ensure `main.py` sets the package when launched directly
- switch to explicit relative imports
- update README usage instructions

## Testing
- `python enhanced_node/main.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68450f0348d883288b2cee2d9beaabee