### PR TITLE
Implement hybrid inference engine

### DIFF
--- a/ultimate_agent/ai/inference/__init__.py
+++ b/ultimate_agent/ai/inference/__init__.py
@@ -1,1070 +1,214 @@
 #!/usr/bin/env python3
 """
-Migration Guide: From Mock Inference to Real Ollama Integration
-
-This guide shows step-by-step how to replace mock inference with real Ollama
-in your existing Ultimate Agent modular architecture.
-"""
-
-# ====================================================================================
-# STEP 1: BACKUP EXISTING INFERENCE ENGINE
-# ====================================================================================
-
-"""
-First, backup your current mock inference implementation:
-"""
-
-# Save ultimate_agent/ai/inference/__init__.py as ultimate_agent/ai/inference/__init___backup.py
-import shutil
-shutil.copy(
-    'ultimate_agent/ai/inference/__init__.py',
-    'ultimate_agent/ai/inference/__init___backup.py'
-)
-
-# ====================================================================================
-# STEP 2: INSTALL DEPENDENCIES
-# ====================================================================================
-
-"""
-Add to requirements.txt:
-"""
-requirements_additions = """
-# Advanced Ollama Integration
-ollama>=0.1.7
-aiohttp>=3.8.0
-GPUtil>=1.4.0  # Optional: GPU monitoring
-"""
-
-print("Add these to requirements.txt:")
-print(requirements_additions)
-
-# ====================================================================================
-# STEP 3: UPDATE CONFIGURATION
-# ====================================================================================
-
-"""
-Add to ultimate_agent_config.ini:
-"""
-
-config_additions = """
-[OLLAMA]
-# Ollama instance configuration
-instances = localhost:11434
-enable_fallback = true
-
-# Performance settings
-default_timeout = 30.0
-max_retries = 3
-retry_delay = 1.0
-
-# Load balancing
-load_balance_strategy = response_time
-health_check_interval = 30.0
-
-# Batching and streaming
-enable_batching = true
-batch_size = 10
-batch_timeout = 1.0
-enable_streaming = true
-
-# Model management
-auto_pull_models = false
-preferred_models = llama2,codellama
-model_cache_size = 5
-"""
-
-print("Add this section to ultimate_agent_config.ini:")
-print(config_additions)
-
-# ====================================================================================
-# STEP 4: CREATE OLLAMA BACKEND (NEW FILE)
-# ====================================================================================
-
-"""
-Create new file: ultimate_agent/ai/backends/__init__.py
-"""
-
-backends_init = """#!/usr/bin/env python3
-\"\"\"
-ultimate_agent/ai/backends/__init__.py
-AI backends package
-\"\"\"
-
-from .ollama_advanced import AdvancedOllamaManager, InferenceRequest, InferenceResponse
-
-__all__ = ['AdvancedOllamaManager', 'InferenceRequest', 'InferenceResponse']
-"""
-
-# Create the backends directory and file
-import os
-os.makedirs('ultimate_agent/ai/backends', exist_ok=True)
-
-with open('ultimate_agent/ai/backends/__init__.py', 'w') as f:
-    f.write(backends_init)
-
-print("✅ Created: ultimate_agent/ai/backends/__init__.py")
-
-# ====================================================================================
-# STEP 5: UPDATE INFERENCE ENGINE (HYBRID APPROACH)
-# ====================================================================================
-
-"""
-Replace ultimate_agent/ai/inference/__init__.py with hybrid implementation:
-"""
-
-new_inference_engine = '''#!/usr/bin/env python3
-"""
 ultimate_agent/ai/inference/__init__.py
-Hybrid Inference Engine: Real Ollama + Mock Fallback
+Hybrid inference engine with optional Advanced Ollama backend.
 
-This replaces the pure mock implementation with real Ollama integration
-while maintaining fallback compatibility.
+This module exposes :class:`HybridInferenceEngine` which prefers the real
+Ollama backend when available and falls back to a lightweight mock
+implementation.  ``InferenceEngine`` is kept as an alias for backwards
+compatibility.
 """
 
-import time
-import random
+from __future__ import annotations
+
 import asyncio
 import logging
-from typing import Dict, Any, List, Optional, Union
+import random
+import time
 from collections import deque
+from typing import Any, Dict, List, Optional
 
-# Try to import advanced Ollama - fallback to mock if not available
 try:
+    # Heavyweight backend providing real model execution.
     from ..backends.ollama_advanced import (
-        AdvancedOllamaManager, 
-        InferenceRequest, 
+        AdvancedOllamaManager,
+        InferenceRequest,
         OllamaInstance,
-        LoadBalanceStrategy
     )
+
     OLLAMA_AVAILABLE = True
-    print("🚀 Advanced Ollama integration available")
-except ImportError as e:
+except Exception as e:  # pragma: no cover - optional dependency
+    logging.warning("Advanced Ollama backend unavailable: %s", e)
     OLLAMA_AVAILABLE = False
-    print(f"⚠️  Advanced Ollama not available, using fallback: {e}")
+    AdvancedOllamaManager = None  # type: ignore
+    InferenceRequest = None  # type: ignore
+    OllamaInstance = None  # type: ignore
 
 
 class HybridInferenceEngine:
-    """
-    Hybrid inference engine that uses real Ollama when available,
-    falls back to mock inference when needed.
-    """
-    
-    def __init__(self, ai_manager):
+    """Inference engine that optionally uses Advanced Ollama."""
+
+    def __init__(self, ai_manager: Any) -> None:
         self.ai_manager = ai_manager
-        self.config = getattr(ai_manager, 'config', None)
-        
-        # Ollama integration
-        self.ollama_manager = None
+        self.config = getattr(ai_manager, "config", None)
+
+        self.ollama_manager: Optional[AdvancedOllamaManager] = None
         self.ollama_available = OLLAMA_AVAILABLE
-        self.enable_fallback = True
         self.ollama_initialized = False
-        
-        # Legacy mock inference (as fallback)
-        self.inference_cache = {}
-        self.inference_history = deque(maxlen=1000)
-        self.performance_stats = {
-            'total_inferences': 0,
-            'successful_inferences': 0,
-            'ollama_inferences': 0,
-            'fallback_inferences': 0,
-            'cache_hits': 0,
-            'total_inference_time': 0.0,
-            'average_confidence': 0.0
+        self.enable_fallback = True
+
+        self.inference_cache: Dict[str, Dict[str, Any]] = {}
+        self.inference_history: deque = deque(maxlen=1000)
+        self.stats = {
+            "total": 0,
+            "success": 0,
+            "ollama": 0,
+            "fallback": 0,
+            "cache_hits": 0,
+            "total_time": 0.0,
         }
-        
-        # Initialize Ollama if available
+
         if self.ollama_available:
             self._init_ollama()
-        
-        print(f"🔮 Hybrid inference engine initialized (Ollama: {self.ollama_available})")
-    
-    def _init_ollama(self):
-        """Initialize Ollama manager"""
+
+    # ------------------------------------------------------------------
+    # Ollama management
+    # ------------------------------------------------------------------
+    def _init_ollama(self) -> None:
+        """Create and configure :class:`AdvancedOllamaManager`."""
         try:
             self.ollama_manager = AdvancedOllamaManager(self.config)
-            
-            # Load configuration
             if self.config:
-                self.enable_fallback = self.config.getboolean('OLLAMA', 'enable_fallback', fallback=True)
-                
-                # Add instances from config
-                instances_str = self.config.get('OLLAMA', 'instances', fallback='localhost:11434')
-                for instance_str in instances_str.split(','):
-                    if ':' in instance_str:
-                        host, port = instance_str.strip().split(':')
-                        self.ollama_manager.add_instance(OllamaInstance(host=host, port=int(port)))
+                instances = self.config.get("OLLAMA", "instances", fallback="localhost:11434")
+                for host in instances.split(","):
+                    if ":" in host:
+                        h, p = host.split(":", 1)
+                        self.ollama_manager.add_instance(OllamaInstance(host=h.strip(), port=int(p)))
                     else:
-                        self.ollama_manager.add_instance(OllamaInstance(host=instance_str.strip()))
+                        self.ollama_manager.add_instance(OllamaInstance(host=host.strip()))
+                self.enable_fallback = self.config.getboolean("OLLAMA", "enable_fallback", fallback=True)
             else:
-                # Default instance
                 self.ollama_manager.add_instance(OllamaInstance(host="localhost"))
-            
-            print(f"✅ Ollama manager configured with {len(self.ollama_manager.instances)} instances")
-            
-        except Exception as e:
-            print(f"⚠️  Failed to initialize Ollama: {e}")
+        except Exception as exc:  # pragma: no cover - runtime protection
+            logging.warning("Failed to initialise Ollama manager: %s", exc)
             self.ollama_available = False
-    
-    async def _ensure_ollama_started(self):
-        """Ensure Ollama manager is started"""
-        if self.ollama_manager and not self.ollama_initialized:
+
+    async def _ensure_ollama_started(self) -> bool:
+        if not self.ollama_available or not self.ollama_manager:
+            return False
+        if not self.ollama_initialized:
             try:
                 await self.ollama_manager.start()
                 self.ollama_initialized = True
-                print("🚀 Ollama manager started")
-            except Exception as e:
-                print(f"❌ Failed to start Ollama manager: {e}")
+            except Exception as exc:  # pragma: no cover - runtime protection
+                logging.warning("Failed to start Ollama manager: %s", exc)
                 if not self.enable_fallback:
                     raise
                 return False
-        return self.ollama_initialized
-    
-    async def run_inference(self, model_name: str, input_data: Any, **kwargs) -> Dict[str, Any]:
-        """
-        Run inference - tries Ollama first, falls back to mock if needed
-        """
-        start_time = time.time()
-        self.performance_stats['total_inferences'] += 1
-        
-        # Try Ollama first if available
-        if self.ollama_available:
-            ollama_result = await self._try_ollama_inference(model_name, input_data, **kwargs)
-            if ollama_result['success']:
-                self.performance_stats['ollama_inferences'] += 1
-                self.performance_stats['successful_inferences'] += 1
-                self._update_performance_stats(ollama_result, time.time() - start_time)
-                return ollama_result
-            elif not self.enable_fallback:
-                # If fallback disabled, return Ollama error
-                return ollama_result
-        
-        # Fallback to mock inference
-        print(f"🔄 Using fallback inference for model: {model_name}")
-        mock_result = await self._mock_inference(model_name, input_data, **kwargs)
-        self.performance_stats['fallback_inferences'] += 1
-        if mock_result['success']:
-            self.performance_stats['successful_inferences'] += 1
-        
-        self._update_performance_stats(mock_result, time.time() - start_time)
-        return mock_result
-    
-    async def _try_ollama_inference(self, model_name: str, input_data: Any, **kwargs) -> Dict[str, Any]:
-        """Try inference with Ollama"""
-        try:
-            # Ensure Ollama is started
-            if not await self._ensure_ollama_started():
-                return {
-                    'success': False,
-                    'error': 'Ollama manager failed to start',
-                    'processing_method': 'ollama_failed'
-                }
-            
-            # Create inference request
-            request = InferenceRequest(
-                model=model_name,
-                prompt=str(input_data),
-                stream=kwargs.get('stream', False),
-                options=kwargs.get('options', {}),
-                timeout=kwargs.get('timeout', 30.0)
-            )
-            
-            # Generate response
-            if request.stream:
-                return await self._handle_ollama_streaming(request)
-            else:
-                response = await self.ollama_manager.generate(request)
-                return self._convert_ollama_response(response, model_name)
-                
-        except Exception as e:
-            return {
-                'success': False,
-                'error': f'Ollama inference failed: {str(e)}',
-                'processing_method': 'ollama_error'
-            }
-    
-    async def _handle_ollama_streaming(self, request: InferenceRequest) -> Dict[str, Any]:
-        """Handle streaming Ollama response"""
-        full_response = ""
-        chunk_count = 0
-        start_time = time.time()
-        
-        try:
-            async for chunk in self.ollama_manager.generate_stream(request):
-                if chunk.success and chunk.response:
-                    full_response += chunk.response
-                    chunk_count += 1
-                elif not chunk.success:
-                    return {
-                        'success': False,
-                        'error': chunk.error,
-                        'processing_method': 'ollama_streaming_failed'
-                    }
-            
-            processing_time = time.time() - start_time
-            
-            return {
-                'success': True,
-                'prediction': full_response,
-                'confidence': 0.95,  # Ollama doesn't provide confidence
-                'model_name': request.model,
-                'processing_time': processing_time,
-                'chunk_count': chunk_count,
-                'tokens_per_second': len(full_response.split()) / processing_time if processing_time > 0 else 0,
-                'processing_method': 'ollama_streaming',
-                'real_inference': True
-            }
-            
-        except Exception as e:
-            return {
-                'success': False,
-                'error': f'Streaming failed: {str(e)}',
-                'processing_method': 'ollama_streaming_error'
-            }
-    
-    def _convert_ollama_response(self, response, model_name: str) -> Dict[str, Any]:
-        """Convert Ollama response to standard format"""
+        return True
+
+    async def _ollama_inference(self, model: str, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        await self._ensure_ollama_started()
+        assert self.ollama_manager and InferenceRequest
+        request = InferenceRequest(model=model, prompt=prompt, options=kwargs.get("options", {}))
+        response = await self.ollama_manager.generate(request)
         return {
-            'success': response.success,
-            'prediction': response.response if response.success else None,
-            'confidence': 0.95 if response.success else 0.0,
-            'error': response.error if not response.success else None,
-            'model_name': model_name,
-            'processing_time': response.processing_time,
-            'tokens_per_second': response.tokens_per_second,
-            'instance_id': response.instance_id,
-            'retry_count': response.retry_count,
-            'processing_method': 'ollama_real',
-            'real_inference': True,
-            'metadata': {
-                'total_duration': response.total_duration,
-                'load_duration': response.load_duration,
-                'eval_count': response.eval_count,
-                'eval_duration': response.eval_duration
-            }
+            "success": response.success,
+            "prediction": response.response if response.success else None,
+            "error": response.error if not response.success else None,
+            "model_name": model,
+            "processing_time": response.processing_time,
+            "tokens_per_second": response.tokens_per_second,
+            "real_inference": True,
         }
-    
-    async def _mock_inference(self, model_name: str, input_data: Any, **kwargs) -> Dict[str, Any]:
-        """Fallback mock inference (based on original implementation)"""
-        
-        # Check cache first
-        cache_key = self._generate_cache_key(model_name, input_data, kwargs)
+
+    # ------------------------------------------------------------------
+    # Mock fallback implementation
+    # ------------------------------------------------------------------
+    async def _mock_inference(self, model: str, prompt: str) -> Dict[str, Any]:
+        await asyncio.sleep(0)  # allow scheduling
+        processing_time = random.uniform(0.1, 0.5)
+        await asyncio.sleep(min(processing_time, 0.2))
+        response = f"Processed '{prompt[:50]}...' with {model} (mock)"
+        return {
+            "success": True,
+            "prediction": response,
+            "confidence": random.uniform(0.7, 0.9),
+            "model_name": model,
+            "processing_time": processing_time,
+            "real_inference": False,
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    async def run_inference(self, model_name: str, input_data: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Execute inference using Ollama or mock fallback."""
+        self.stats["total"] += 1
+        start = time.time()
+        prompt = str(input_data)
+        cache_key = f"{model_name}:{prompt}"[:256]
+
         if cache_key in self.inference_cache:
-            cached_result = self.inference_cache[cache_key].copy()
-            cached_result['cached'] = True
-            self.performance_stats['cache_hits'] += 1
-            return cached_result
-        
-        # Simulate processing time
-        processing_time = random.uniform(0.5, 2.0)
-        await asyncio.sleep(min(processing_time, 1.0))  # Cap sleep for demo
-        
-        # Generate mock response based on model type
-        if model_name in ['sentiment', 'llama2', 'mistral']:
-            result = self._mock_text_response(input_data, processing_time)
-        elif model_name in ['codellama', 'code']:
-            result = self._mock_code_response(input_data, processing_time)
+            self.stats["cache_hits"] += 1
+            result = self.inference_cache[cache_key].copy()
+            result["cached"] = True
+            return result
+
+        if self.ollama_available:
+            try:
+                result = await self._ollama_inference(model_name, prompt, **kwargs)
+                if result.get("success"):
+                    self.stats["ollama"] += 1
+                    self.stats["success"] += 1
+                else:
+                    if not self.enable_fallback:
+                        self._record_stats(result, time.time() - start)
+                        return result
+                    result = await self._mock_inference(model_name, prompt)
+            except Exception as exc:  # pragma: no cover - runtime protection
+                logging.warning("Ollama inference failed: %s", exc)
+                if not self.enable_fallback:
+                    raise
+                result = await self._mock_inference(model_name, prompt)
         else:
-            result = self._mock_generic_response(input_data, processing_time)
-        
-        result.update({
-            'model_name': model_name,
-            'cached': False,
-            'processing_method': 'mock_fallback',
-            'real_inference': False,
-            'fallback_reason': 'Ollama unavailable or failed'
-        })
-        
-        # Cache the result
+            result = await self._mock_inference(model_name, prompt)
+
+        if result.get("success"):
+            self.stats["success"] += 1
+        else:
+            self.stats["fallback"] += 1
+        self._record_stats(result, time.time() - start)
         self.inference_cache[cache_key] = result.copy()
-        
+        self.inference_history.appendleft({"model": model_name, "prompt": prompt, "result": result})
+        result["cached"] = False
         return result
-    
-    def _mock_text_response(self, input_data: str, processing_time: float) -> Dict[str, Any]:
-        """Generate mock text response"""
-        text = str(input_data).lower()
-        
-        # Simple sentiment/response logic
-        if any(word in text for word in ['good', 'great', 'awesome', 'excellent']):
-            response = "That's wonderful! I'm glad to hear positive feedback."
-            confidence = random.uniform(0.85, 0.95)
-        elif any(word in text for word in ['bad', 'terrible', 'awful', 'horrible']):
-            response = "I understand your concerns. Let me help address that."
-            confidence = random.uniform(0.8, 0.9)
-        elif 'explain' in text or 'what is' in text:
-            response = f"Here's an explanation of {text[:50]}... [This is a mock response for demonstration]"
-            confidence = random.uniform(0.75, 0.85)
-        else:
-            response = f"Thank you for your input about {text[:30]}... I've processed your request."
-            confidence = random.uniform(0.7, 0.8)
-        
-        return {
-            'success': True,
-            'prediction': response,
-            'confidence': confidence,
-            'processing_time': processing_time,
-            'tokens_per_second': len(response.split()) / processing_time if processing_time > 0 else 0
-        }
-    
-    def _mock_code_response(self, input_data: str, processing_time: float) -> Dict[str, Any]:
-        """Generate mock code response"""
-        language = 'python'  # Default
-        if 'javascript' in str(input_data).lower() or 'js' in str(input_data).lower():
-            language = 'javascript'
-        elif 'java' in str(input_data).lower():
-            language = 'java'
-        
-        if language == 'python':
-            code = '''def example_function(data):
-    """Auto-generated function based on your request"""
-    result = []
-    for item in data:
-        result.append(item * 2)
-    return result'''
-        elif language == 'javascript':
-            code = '''function exampleFunction(data) {
-    // Auto-generated function based on your request
-    return data.map(item => item * 2);
-}'''
-        else:
-            code = '''public class Example {
-    public static void main(String[] args) {
-        // Auto-generated code based on your request
-        System.out.println("Hello, World!");
-    }
-}'''
-        
-        return {
-            'success': True,
-            'prediction': code,
-            'confidence': random.uniform(0.8, 0.9),
-            'processing_time': processing_time,
-            'language': language,
-            'tokens_per_second': len(code.split()) / processing_time if processing_time > 0 else 0
-        }
-    
-    def _mock_generic_response(self, input_data: str, processing_time: float) -> Dict[str, Any]:
-        """Generate mock generic response"""
-        responses = [
-            "I've processed your request and generated a response.",
-            "Based on your input, here's what I found.",
-            "Your query has been analyzed and here's the result.",
-            "Processing complete. Here's the generated output.",
-            "Thank you for your request. Here's my response."
-        ]
-        
-        return {
-            'success': True,
-            'prediction': random.choice(responses),
-            'confidence': random.uniform(0.7, 0.85),
-            'processing_time': processing_time,
-            'tokens_per_second': random.uniform(10, 30)
-        }
-    
-    def _generate_cache_key(self, model_name: str, input_data: Any, kwargs: Dict) -> str:
-        """Generate cache key for inference result"""
-        import hashlib
-        import json
-        
-        cache_data = f"{model_name}:{str(input_data)[:100]}:{json.dumps(kwargs, sort_keys=True)}"
-        return hashlib.md5(cache_data.encode()).hexdigest()
-    
-    def _update_performance_stats(self, result: Dict[str, Any], inference_time: float):
-        """Update performance statistics"""
-        self.performance_stats['total_inference_time'] += inference_time
-        
-        if result.get('confidence', 0) > 0:
-            # Update running average confidence
-            total_successful = self.performance_stats['successful_inferences']
-            current_avg = self.performance_stats['average_confidence']
-            confidence = result['confidence']
-            
-            if total_successful > 0:
-                self.performance_stats['average_confidence'] = (
-                    (current_avg * (total_successful - 1) + confidence) / total_successful
-                )
-            else:
-                self.performance_stats['average_confidence'] = confidence
-    
-    def get_performance_stats(self) -> Dict[str, Any]:
-        """Get comprehensive performance statistics"""
-        total = self.performance_stats['total_inferences']
-        successful = self.performance_stats['successful_inferences']
-        
-        stats = self.performance_stats.copy()
-        
-        # Calculate derived statistics
-        stats['success_rate'] = successful / total if total > 0 else 0.0
-        stats['average_inference_time'] = (
-            self.performance_stats['total_inference_time'] / total if total > 0 else 0.0
-        )
-        stats['cache_hit_rate'] = (
-            self.performance_stats['cache_hits'] / total if total > 0 else 0.0
-        )
-        stats['ollama_usage_rate'] = (
-            self.performance_stats['ollama_inferences'] / total if total > 0 else 0.0
-        )
-        stats['fallback_usage_rate'] = (
-            self.performance_stats['fallback_inferences'] / total if total > 0 else 0.0
-        )
-        
-        # Add Ollama-specific stats if available
-        if self.ollama_manager and self.ollama_initialized:
-            ollama_stats = self.ollama_manager.get_stats()
-            stats['ollama_system_stats'] = ollama_stats
-            stats['ollama_instances'] = self.ollama_manager.get_instance_stats()
-        
-        stats['cache_size'] = len(self.inference_cache)
-        stats['history_size'] = len(self.inference_history)
-        stats['ollama_available'] = self.ollama_available
-        stats['ollama_initialized'] = self.ollama_initialized
-        
-        return stats
-    
+
+    def _record_stats(self, result: Dict[str, Any], duration: float) -> None:
+        self.stats["total_time"] += duration
+
     async def list_models(self) -> List[str]:
-        """Get available models"""
-        models = set()
-        
-        # Add Ollama models if available
         if self.ollama_available and await self._ensure_ollama_started():
             try:
-                ollama_models = await self.ollama_manager.get_available_models()
-                models.update(ollama_models)
-            except Exception as e:
-                print(f"⚠️  Failed to get Ollama models: {e}")
-        
-        # Add fallback models
-        fallback_models = ['sentiment', 'classification', 'regression', 'llama2', 'codellama', 'mistral']
-        models.update(fallback_models)
-        
-        return list(models)
-    
-    async def pull_model(self, model_name: str) -> Dict[str, Any]:
-        """Pull model to Ollama instances"""
-        if not self.ollama_available:
-            return {
-                'success': False,
-                'error': 'Ollama not available',
-                'fallback': 'Model will be available as mock'
-            }
-        
-        if not await self._ensure_ollama_started():
-            return {
-                'success': False,
-                'error': 'Failed to start Ollama manager'
-            }
-        
-        try:
-            results = await self.ollama_manager.pull_model(model_name)
-            return {
-                'success': any(results.values()),
-                'results': results,
-                'model': model_name
-            }
-        except Exception as e:
-            return {
-                'success': False,
-                'error': str(e),
-                'model': model_name
-            }
-    
-    def clear_cache(self):
-        """Clear inference cache"""
-        cache_size = len(self.inference_cache)
-        self.inference_cache.clear()
-        print(f"🗑️ Cleared inference cache: {cache_size} entries removed")
-    
-    def get_status(self) -> Dict[str, Any]:
-        """Get inference engine status"""
-        status = {
-            'ollama_available': self.ollama_available,
-            'ollama_initialized': self.ollama_initialized,
-            'enable_fallback': self.enable_fallback,
-            'total_models_available': len(self.list_models()) if hasattr(self, 'list_models') else 0,
-            'cache_size': len(self.inference_cache),
-            'performance_stats': self.get_performance_stats()
+                models = await self.ollama_manager.get_available_models()
+                return list(models)
+            except Exception as exc:  # pragma: no cover - runtime protection
+                logging.warning("Failed to list Ollama models: %s", exc)
+        return []
+
+    def get_performance_stats(self) -> Dict[str, Any]:
+        total = max(self.stats["total"], 1)
+        return {
+            "total_inferences": self.stats["total"],
+            "success_rate": self.stats["success"] / total,
+            "ollama_usage_rate": self.stats["ollama"] / total,
+            "fallback_usage_rate": self.stats["fallback"] / total,
+            "cache_hit_rate": self.stats["cache_hits"] / total,
+            "average_inference_time": self.stats["total_time"] / total,
         }
-        
-        if self.ollama_manager and self.ollama_initialized:
-            status['ollama_instances'] = len(self.ollama_manager.instances)
-            status['ollama_stats'] = self.ollama_manager.get_stats()
-        
-        return status
-    
-    async def close(self):
-        """Clean shutdown"""
+
+    def clear_cache(self) -> None:
+        self.inference_cache.clear()
+
+    async def close(self) -> None:
         if self.ollama_manager and self.ollama_initialized:
             await self.ollama_manager.stop()
-            print("🛑 Hybrid inference engine stopped")
+            self.ollama_initialized = False
 
 
-# Create backward-compatible alias
+# Backwards compatibility -------------------------------------------------------
 InferenceEngine = HybridInferenceEngine
 
-# Keep original function signatures for compatibility
-def create_inference_engine(ai_manager):
-    """Factory function for backward compatibility"""
+def create_inference_engine(ai_manager: Any) -> HybridInferenceEngine:
+    """Factory used by older code."""
     return HybridInferenceEngine(ai_manager)
-'''
-
-# Write the new inference engine
-with open('ultimate_agent/ai/inference/__init__.py', 'w') as f:
-    f.write(new_inference_engine)
-
-print("✅ Updated: ultimate_agent/ai/inference/__init__.py")
-
-# ====================================================================================
-# STEP 6: UPDATE AI MODEL MANAGER
-# ====================================================================================
-
-"""
-Update ultimate_agent/ai/models/ai_models.py to use hybrid inference:
-"""
-
-updated_ai_models = '''#!/usr/bin/env python3
-"""
-ultimate_agent/ai/models/ai_models.py
-Enhanced AI model management with real Ollama integration
-"""
-
-import time
-import asyncio
-from typing import Dict, Any, Callable, List
-
-# Import the hybrid inference engine
-from ..inference import HybridInferenceEngine
-
-
-class AIModelManager:
-    """Enhanced AI Model Manager with Ollama integration"""
-    
-    def __init__(self, config_manager=None):
-        self.config = config_manager
-        self.gpu_available = self.check_gpu_availability()
-        
-        # Initialize hybrid inference engine
-        self.inference_engine = HybridInferenceEngine(self)
-        
-        # Legacy model definitions (for compatibility)
-        self.models = {
-            'sentiment': {
-                'type': 'nlp',
-                'status': 'loaded',
-                'size': 'small',
-                'accuracy': 0.85,
-                'description': 'Sentiment analysis model'
-            },
-            'classification': {
-                'type': 'vision',
-                'status': 'loaded',
-                'size': 'medium',
-                'accuracy': 0.92,
-                'description': 'Image classification model'
-            },
-            'regression': {
-                'type': 'tabular',
-                'status': 'loaded',
-                'size': 'small',
-                'accuracy': 0.88,
-                'description': 'Regression model'
-            },
-            'llama2': {
-                'type': 'nlp_advanced',
-                'status': 'loaded',
-                'size': 'large',
-                'accuracy': 0.94,
-                'description': 'Llama 2 language model'
-            },
-            'codellama': {
-                'type': 'code',
-                'status': 'loaded',
-                'size': 'large',
-                'accuracy': 0.91,
-                'description': 'Code Llama programming model'
-            },
-            'mistral': {
-                'type': 'nlp_advanced',
-                'status': 'loaded',
-                'size': 'large',
-                'accuracy': 0.93,
-                'description': 'Mistral language model'
-            }
-        }
-        
-        # Training engine and other components (keep existing)
-        self.training_engine = None
-        self.model_cache = {}
-        self.training_sessions = {}
-        
-        # Initialize components
-        self.init_training_engine()
-        
-        print(f"🧠 Enhanced AI models loaded: {len(self.models)} models (Ollama: {self.inference_engine.ollama_available})")
-    
-    def check_gpu_availability(self) -> bool:
-        """Check if GPU acceleration is available"""
-        try:
-            import torch
-            if torch.cuda.is_available():
-                print("🚀 GPU acceleration available")
-                return True
-            else:
-                print("💻 Using CPU for AI computations")
-                return False
-        except ImportError:
-            print("⚠️ PyTorch not available, checking system GPU")
-            try:
-                import GPUtil
-                gpus = GPUtil.getGPUs()
-                if gpus:
-                    print(f"🚀 {len(gpus)} GPU(s) detected")
-                    return True
-            except ImportError:
-                pass
-            print("💻 No GPU acceleration detected")
-            return False
-    
-    def init_training_engine(self):
-        """Initialize training engine (keep existing implementation)"""
-        try:
-            from ..training import AITrainingEngine
-            self.training_engine = AITrainingEngine(self)
-            print(f"🎓 Training engine initialized: {len(self.training_engine.training_tasks)} task types")
-        except Exception as e:
-            print(f"⚠️ Training engine initialization warning: {e}")
-    
-    def get_model(self, model_name: str) -> Dict[str, Any]:
-        """Get model information"""
-        return self.models.get(model_name, {})
-    
-    def list_models(self) -> List[str]:
-        """List all available models (both legacy and Ollama)"""
-        try:
-            # Get models from Ollama if possible
-            if hasattr(self.inference_engine, 'list_models'):
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                try:
-                    ollama_models = loop.run_until_complete(self.inference_engine.list_models())
-                    # Combine with legacy models
-                    all_models = set(list(self.models.keys()) + ollama_models)
-                    return list(all_models)
-                finally:
-                    loop.close()
-        except Exception as e:
-            print(f"⚠️ Failed to get Ollama models: {e}")
-        
-        # Fallback to legacy models
-        return list(self.models.keys())
-    
-    def get_models_by_type(self, model_type: str) -> List[str]:
-        """Get models of specific type"""
-        return [name for name, info in self.models.items() 
-                if info.get('type') == model_type]
-    
-    def run_inference(self, model_name: str, input_data: Any, **kwargs) -> Dict[str, Any]:
-        """
-        Run inference using hybrid engine (Ollama + fallback)
-        
-        This method maintains backward compatibility while adding real Ollama support.
-        """
-        try:
-            # Use asyncio to run the hybrid inference
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                result = loop.run_until_complete(
-                    self.inference_engine.run_inference(model_name, input_data, **kwargs)
-                )
-                return result
-            finally:
-                loop.close()
-                
-        except Exception as e:
-            print(f"❌ Inference failed: {e}")
-            # Emergency fallback
-            return {
-                'success': False,
-                'error': str(e),
-                'model_used': model_name,
-                'processing_method': 'emergency_fallback'
-            }
-    
-    def start_training(self, task_type: str, config: Dict, progress_callback: Callable) -> Dict[str, Any]:
-        """Start AI training task (keep existing implementation)"""
-        if self.training_engine:
-            return self.training_engine.start_training(task_type, config, progress_callback)
-        
-        return {'success': False, 'error': 'Training engine not available'}
-    
-    def get_training_capabilities(self) -> List[str]:
-        """Get available training task types"""
-        if self.training_engine:
-            return list(self.training_engine.training_tasks.keys())
-        return []
-    
-    def get_model_stats(self) -> Dict[str, Any]:
-        """Get comprehensive model statistics"""
-        stats = {
-            'total_models': len(self.models),
-            'models_by_type': self._group_models_by_type(),
-            'gpu_available': self.gpu_available,
-            'training_sessions_active': len(self.training_sessions),
-            'training_capabilities': self.get_training_capabilities(),
-            'cache_size': len(self.model_cache),
-            'models': self.models,
-            'inference_engine_stats': self.inference_engine.get_performance_stats()
-        }
-        
-        # Add Ollama-specific stats
-        if self.inference_engine.ollama_available:
-            stats['ollama_integration'] = True
-            stats['ollama_stats'] = self.inference_engine.get_status()
-        else:
-            stats['ollama_integration'] = False
-            stats['fallback_mode'] = True
-        
-        return stats
-    
-    def _group_models_by_type(self) -> Dict[str, int]:
-        """Group models by type for statistics"""
-        type_counts = {}
-        for model_info in self.models.values():
-            model_type = model_info.get('type', 'unknown')
-            type_counts[model_type] = type_counts.get(model_type, 0) + 1
-        return type_counts
-    
-    def get_status(self) -> Dict[str, Any]:
-        """Get enhanced AI manager status"""
-        return {
-            'models_loaded': len(self.models),
-            'gpu_available': self.gpu_available,
-            'training_engine_active': self.training_engine is not None,
-            'inference_engine_active': True,
-            'inference_engine_type': 'hybrid_ollama',
-            'ollama_available': self.inference_engine.ollama_available,
-            'ollama_initialized': self.inference_engine.ollama_initialized,
-            'active_training_sessions': len(self.training_sessions),
-            'model_types': list(set(info.get('type') for info in self.models.values())),
-            'performance_stats': self.inference_engine.get_performance_stats()
-        }
-    
-    def load_model(self, model_name: str, model_config: Dict[str, Any]) -> bool:
-        """Load a new model"""
-        try:
-            self.models[model_name] = {
-                'type': model_config.get('type', 'custom'),
-                'status': 'loaded',
-                'size': model_config.get('size', 'medium'),
-                'accuracy': model_config.get('accuracy', 0.0),
-                'loaded_at': time.time(),
-                'description': model_config.get('description', f'Custom model: {model_name}')
-            }
-            print(f"✅ Model loaded: {model_name}")
-            return True
-        except Exception as e:
-            print(f"❌ Failed to load model {model_name}: {e}")
-            return False
-    
-    async def pull_ollama_model(self, model_name: str) -> Dict[str, Any]:
-        """Pull model to Ollama instances"""
-        return await self.inference_engine.pull_model(model_name)
-    
-    def clear_inference_cache(self):
-        """Clear inference cache"""
-        self.inference_engine.clear_cache()
-    
-    def optimize_models(self) -> Dict[str, Any]:
-        """Optimize model performance"""
-        try:
-            optimized_count = 0
-            for model_name, model_info in self.models.items():
-                if model_info.get('status') == 'loaded':
-                    model_info['optimized'] = True
-                    optimized_count += 1
-            
-            return {
-                'success': True,
-                'optimized_models': optimized_count,
-                'total_models': len(self.models),
-                'ollama_optimization': self.inference_engine.ollama_available
-            }
-        except Exception as e:
-            return {'success': False, 'error': str(e)}
-    
-    async def close(self):
-        """Clean shutdown"""
-        if self.inference_engine:
-            await self.inference_engine.close()
-        print("🧠 AI Model Manager closed")
-
-
-# For backward compatibility
-def create_ai_model_manager(config_manager=None):
-    """Factory function for creating AI model manager"""
-    return AIModelManager(config_manager)
-'''
-
-# Write the updated AI models file
-with open('ultimate_agent/ai/models/ai_models.py', 'w') as f:
-    f.write(updated_ai_models)
-
-print("✅ Updated: ultimate_agent/ai/models/ai_models.py")
-
-# ====================================================================================
-# STEP 7: TEST THE MIGRATION
-# ====================================================================================
-
-"""
-Create a test script to verify the migration works:
-"""
-
-test_script = '''#!/usr/bin/env python3
-"""
-test_migration.py
-Test script to verify Ollama integration works
-"""
-
-import asyncio
-import sys
-import os
-
-# Add path for imports
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-from ultimate_agent.config.config_settings import ConfigManager
-from ultimate_agent.ai.models.ai_models import AIModelManager
-
-async def test_inference_migration():
-    """Test the migrated inference system"""
-    print("🧪 Testing Ollama Integration Migration")
-    print("=" * 50)
-    
-    # Initialize components
-    config = ConfigManager()
-    ai_manager = AIModelManager(config)
-    
-    # Test 1: List available models
-    print("\\n1. Testing model listing...")
-    models = ai_manager.list_models()
-    print(f"   Available models: {models}")
-    
-    # Test 2: Get system status
-    print("\\n2. Testing system status...")
-    status = ai_manager.get_status()
-    print(f"   Ollama available: {status['ollama_available']}")
-    print(f"   Inference engine: {status['inference_engine_type']}")
-    
-    # Test 3: Run inference tests
-    print("\\n3. Testing inference...")
-    
-    test_cases = [
-        ("llama2", "Hello, how are you?"),
-        ("sentiment", "This is a great day!"),
-        ("codellama", "Write a Python function to sort a list")
-    ]
-    
-    for model, prompt in test_cases:
-        print(f"\\n   Testing {model} with: '{prompt[:30]}...'")
-        
-        result = ai_manager.run_inference(model, prompt)
-        
-        if result['success']:
-            print(f"   ✅ Success! Method: {result['processing_method']}")
-            print(f"   📝 Response: {result['prediction'][:100]}...")
-            print(f"   ⏱️  Time: {result.get('processing_time', 0):.2f}s")
-            if result.get('real_inference'):
-                print(f"   🚀 Real Ollama inference!")
-            else:
-                print(f"   🔄 Fallback inference")
-        else:
-            print(f"   ❌ Failed: {result.get('error', 'Unknown error')}")
-    
-    # Test 4: Performance statistics
-    print("\\n4. Performance Statistics...")
-    perf_stats = ai_manager.inference_engine.get_performance_stats()
-    print(f"   Total inferences: {perf_stats['total_inferences']}")
-    print(f"   Success rate: {perf_stats['success_rate']:.2%}")
-    print(f"   Ollama usage: {perf_stats['ollama_usage_rate']:.2%}")
-    print(f"   Fallback usage: {perf_stats['fallback_usage_rate']:.2%}")
-    
-    # Test 5: Model pulling (if Ollama available)
-    if status['ollama_available']:
-        print("\\n5. Testing model pulling...")
-        try:
-            pull_result = await ai_manager.pull_ollama_model("llama2")
-            if pull_result['success']:
-                print("   ✅ Model pull successful!")
-            else:
-                print(f"   ⚠️  Model pull failed: {pull_result.get('error')}")
-        except Exception as e:
-            print(f"   ⚠️  Model pull error: {e}")
-    
-    # Cleanup
-    await ai_manager.close()
-    
-    print("\\n✅ Migration test completed!")
-    print("\\n📋 Summary:")
-    print(f"   - Ollama integration: {'✅ Working' if status['ollama_available'] else '❌ Not available'}")
-    print(f"   - Fallback system: ✅ Working")
-    print(f"   - Backward compatibility: ✅ Maintained")
-
-if __name__ == "__main__":
-    asyncio.run(test_inference_migration())
-'''
-
-# Write test script
-with open('test_migration.py', 'w') as f:
-    f.write(test_script)
-
-print("✅ Created: test_migration.py")
-
-# ====================================================================================
-# STEP 8: VERIFICATION SCRIPT
-# ====================================================================================
-
-def verify_migration():
-    """Verify migration was successful"""
-    print("\n🔍 Verifying Migration...")
-    print("=" * 40)
-    
-    # Check required files exist
-    required_files = [
-        'ultimate_agent/ai/backends/__init__.py',
-        'ultimate_agent/ai/backends/ollama_advanced.py',  # Should be created from first artifact
-        'ultimate_agent/ai/inference/__init__.py',
-        'ultimate_agent/ai/models/ai_models.py',
-        'test_migration.py'
-    ]
-    
-    for file_path in required_files:
-        if os.path.exists(file_path):
-            print(f"   ✅ {file_path}")
-        else:
-            print(f"   ❌ {file_path} - MISSING!")
-    
-    # Check backup exists
-    backup_file = 'ultimate_agent/ai/inference/__init___backup.py'
-    if os.path.exists(backup_file):
-        print(f"   ✅ {backup_file} (backup)")
-    else:
-        print(f"   ⚠️  {backup_file} - No backup found")
-    
-    print("\n📋 Next Steps:")
-    print("   1. Install dependencies: pip install ollama aiohttp")
-    print("   2. Install Ollama: curl -fsSL https://ollama.ai/install.sh | sh")
-    print("   3. Start Ollama: ollama serve")
-    print("   4. Pull a model: ollama pull llama2")
-    print("   5. Run test: python test_migration.py")
-    print("   6. Start your agent: python main.py")
-    
-    return True
-
-# Run verification
-verify_migration()
-
-print("\n🎉 Migration Complete!")
-print("Your Ultimate Agent now supports real Ollama inference with intelligent fallback!")
-print("\nTo complete the setup:")
-print("1. Run: pip install ollama aiohttp")
-print("2. Install and start Ollama server")
-print("3. Test with: python test_migration.py")


### PR DESCRIPTION
## Summary
- replace migration script with actual hybrid inference engine
- provide fallback inference when Advanced Ollama backend is unavailable

## Testing
- `python3 -m py_compile ultimate_agent/ai/inference/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846c6915a788328a99f6d4de8153234