### PR TITLE
Fix config import and main module path

### DIFF
--- a/ultimate_agent/config/__init__.py
+++ b/ultimate_agent/config/__init__.py
@@ -1,5 +1,12 @@
 # ultimate_agent/config/__init__.py
 
-from .settings import config  # ✅ import the renamed variable
+"""Package initialization for configuration module."""
 
-print(settings['port'])  # ✅ This works
+# Import the settings dictionary from settings.py
+from .settings import settings
+
+# Export `config` as an alias for backward compatibility
+config = settings
+
+# Simple sanity check to ensure settings were loaded
+print(settings["port"])

--- a/ultimate_agent/core/container.py
+++ b/ultimate_agent/core/container.py
@@ -26,7 +26,8 @@ from ..config.settings import settings
 
 class Container(containers.DeclarativeContainer):
     config = providers.Configuration()
-    config.override(settings.dict())
+    # Override configuration with loaded settings dictionary
+    config.override(settings)
 
     # Example: Register components here
     # logger = providers.Singleton(YourLoggerClass)

--- a/ultimate_agent/main.py
+++ b/ultimate_agent/main.py
@@ -5,17 +5,13 @@ Main entry point for the Ultimate Agent
 """
 
 import sys
-import os
-from pathlib import Path
 
-# Add the ultimate_agent directory to Python path  
-sys.path.insert(0, str(Path(__file__).parent))
 
 def main():
     """Main entry point for Ultimate Agent"""
     try:
-        from core.agent import UltimateAgent
-        from config.settings import get_config
+        from .core.agent import UltimateAgent
+        from .config.settings import get_config
 
         print("🤖 Initializing Ultimate Agent...")
         config = get_config()


### PR DESCRIPTION
## Summary
- correct module import in `ultimate_agent.config`
- adjust container to use plain dictionary settings
- update `main.py` to use package-relative imports

## Testing
- `pytest -q`
- `python3 -m ultimate_agent.main` *(fails: AIModelManager.__init__ takes 1 positional argument but 2 were given)*

------
https://chatgpt.com/codex/tasks/task_e_6847aee3daf0832882199c56b59de7a4