### PR TITLE
Fix node server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ curl -X POST http://localhost:8080/api/start_task \
 
 ```ini
 [DEFAULT]
-node_url = https://srvnodes.peoplesainetwork.com:443
+node_url = https://srvnodes.peoplesainetwork.com
 dashboard_port = 8080
 heartbeat_interval = 30
 auto_start_tasks = true
@@ -593,7 +593,7 @@ python main.py --monitor-memory
 #### **Blockchain Connection Issues**
 ```bash
 # Test network connectivity
-curl -X GET https://srvnodes.peoplesainetwork.com:443/api/health
+curl -X GET https://srvnodes.peoplesainetwork.com/api/health
 
 # Use demo mode
 python main.py --blockchain-demo-mode

--- a/enhanced_node/cli_tool.py
+++ b/enhanced_node/cli_tool.py
@@ -797,7 +797,7 @@ def add_version_commands(cli_parser):
 class VersionControlCLI:
     """Version Control CLI Commands"""
     
-    def __init__(self, base_url='https://localhost:443'):
+    def __init__(self, base_url='http://localhost:5000'):
         self.base_url = base_url
         
     def handle_version_command(self, args):

--- a/enhanced_node/comprehensive_readme.txt
+++ b/enhanced_node/comprehensive_readme.txt
@@ -450,7 +450,7 @@ remote_manager = AdvancedRemoteControlManager(mock_server)
 
 ```bash
 # Production configuration via environment variables
-export NODE_PORT=443
+export NODE_PORT=5000
 export DATABASE_URL="postgresql://user:pass@localhost/nodedb"
 export REDIS_URL="redis://localhost:6379"
 export LOG_LEVEL="INFO"

--- a/enhanced_node/comprehensive_setup.py
+++ b/enhanced_node/comprehensive_setup.py
@@ -199,7 +199,7 @@ def check_port_availability():
     import socket
     
     ports_to_check = [
-        (443, "Main server port"),
+        (5000, "Main server port"),
         (8091, "Metrics server port")
     ]
     
@@ -283,7 +283,7 @@ def main():
         print("=" * 90)
         print()
         print("🌟 Enhanced Node Server is ready to start!")
-        print("📡 Dashboard will be available at: https://localhost:443")
+        print("📡 Dashboard will be available at: http://localhost:5000")
         print("📊 Metrics will be available at: http://localhost:8091")
         print("🎮 Advanced Features: ✅ Enabled")
         print("🏗️ Modular Architecture: ✅ Enabled")

--- a/enhanced_node/config/settings.py
+++ b/enhanced_node/config/settings.py
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
     
     # Node Configuration
     NODE_VERSION: str = "3.4.0-advanced-remote-control"
-    NODE_PORT: int = 443
+    NODE_PORT: int = 5000
     NODE_HOST: str = "127.0.0.1"
     MANAGER_HOST: str = "srvnodes.peoplesainetwork.com"
     MANAGER_PORT: int = 443

--- a/enhanced_node/core/server.py
+++ b/enhanced_node/core/server.py
@@ -56,7 +56,7 @@ except ImportError as e1:
         class MockSettings:
             NODE_ID = "enhanced-node-emergency"
             NODE_VERSION = "3.4.0-emergency"
-            NODE_PORT = 443
+            NODE_PORT = 5000
             MANAGER_HOST = "localhost"
             MANAGER_PORT = 8080
             DEFAULT_RATE_LIMITS = ["100 per hour"]

--- a/enhanced_node/docker_compose.txt
+++ b/enhanced_node/docker_compose.txt
@@ -7,11 +7,11 @@ services:
     container_name: enhanced-node-server
     restart: unless-stopped
     ports:
-      - "443:443"   # Main server
+      - "5000:5000"   # Main server
       - "8091:8091"   # Prometheus metrics
     environment:
       - NODE_ENV=production
-      - NODE_PORT=443
+      - NODE_PORT=5000
       - METRICS_PORT=8091
       - REDIS_HOST=redis
       - REDIS_PORT=6379

--- a/enhanced_node/docker_config.txt
+++ b/enhanced_node/docker_config.txt
@@ -10,7 +10,7 @@ LABEL description="Enhanced Ultimate Pain Network Node Server - Modular Architec
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     NODE_ENV=production \
-    NODE_PORT=443 \
+    NODE_PORT=5000 \
     METRICS_PORT=8091
 
 # Set work directory

--- a/enhanced_node/docker_support.sh
+++ b/enhanced_node/docker_support.sh
@@ -11,7 +11,7 @@ echo "=============================================="
 # Environment setup
 export PYTHONPATH="/app:$PYTHONPATH"
 export NODE_ENV=${NODE_ENV:-production}
-export NODE_PORT=${NODE_PORT:-443}
+export NODE_PORT=${NODE_PORT:-5000}
 export METRICS_PORT=${METRICS_PORT:-8091}
 
 # Function to wait for service

--- a/enhanced_node/environment_configs.sh
+++ b/enhanced_node/environment_configs.sh
@@ -13,7 +13,7 @@ NODE_ID=enhanced-node-production-001
 NODE_VERSION=3.4.0-advanced-remote-control
 
 # Network configuration
-NODE_PORT=443
+NODE_PORT=5000
 METRICS_PORT=8091
 
 # Manager configuration

--- a/enhanced_node/fixed_setup_run.py
+++ b/enhanced_node/fixed_setup_run.py
@@ -170,7 +170,7 @@ def check_port_availability():
     import socket
     
     ports_to_check = [
-        (443, "Main server port"),
+        (5000, "Main server port"),
         (8091, "Metrics server port")
     ]
     
@@ -277,7 +277,7 @@ def main():
         print("=" * 90)
         print()
         print("🌟 Enhanced Node Server is ready to start!")
-        print("📡 Dashboard will be available at: https://localhost:443")
+        print("📡 Dashboard will be available at: http://localhost:5000")
         print("📊 Metrics will be available at: http://localhost:8091")
         print("🎮 Advanced Features: ✅ Enabled")
         print("🏗️ Modular Architecture: ✅ Enabled")

--- a/enhanced_node/main.py
+++ b/enhanced_node/main.py
@@ -238,11 +238,11 @@ if __name__ == "__main__":
             from config.settings import NODE_PORT
             port = NODE_PORT
         except ImportError:
-            port = 443
+            port = 5000
         
         print(f"\n🌐 Enhanced Node Server running on:")
-        print(f"   📱 Dashboard: https://localhost:{port}")
-        print(f"   📊 Health Check: https://localhost:{port}/health")
+        print(f"   📱 Dashboard: http://localhost:{port}")
+        print(f"   📊 Health Check: http://localhost:{port}/health")
         print(f"   🔍 Debug Info: http://localhost:{port}/debug")
         print(f"   🔌 WebSocket: ws://localhost:{port}/socket.io/")
         

--- a/enhanced_node/modularization_complete.md
+++ b/enhanced_node/modularization_complete.md
@@ -176,9 +176,9 @@ python main.py
 ✅ **Direct run** - if dependencies already installed
 
 ### **Access Points Ready**
-- ✅ **Dashboard**: https://localhost:443
+- ✅ **Dashboard**: http://localhost:5000
 - ✅ **Metrics**: http://localhost:8091
-- ✅ **All APIs**: https://localhost:443/api/...
+- ✅ **All APIs**: http://localhost:5000/api/...
 
 ---
 

--- a/enhanced_node/nginx_config.txt
+++ b/enhanced_node/nginx_config.txt
@@ -4,7 +4,7 @@
 # Main server configuration
 upstream enhanced_node_backend {
     # Multiple server instances for load balancing
-    server 127.0.0.1:443 weight=3 max_fails=3 fail_timeout=30s;
+    server 127.0.0.1:5000 weight=3 max_fails=3 fail_timeout=30s;
     server 127.0.0.1:5001 weight=2 max_fails=3 fail_timeout=30s backup;
     
     # Health check
@@ -19,7 +19,7 @@ upstream enhanced_node_metrics {
 
 upstream enhanced_node_websocket {
     # WebSocket-specific upstream
-    server 127.0.0.1:443;
+    server 127.0.0.1:5000;
     
     # WebSocket settings
     ip_hash;  # Ensure session persistence for WebSocket connections

--- a/enhanced_node/readme_file.md
+++ b/enhanced_node/readme_file.md
@@ -118,10 +118,10 @@ python -m enhanced_node.main
 
 Once running, the server provides:
 
-- **Dashboard**: https://localhost:443
+- **Dashboard**: http://localhost:5000
 - **Metrics**: http://localhost:8091
-- **API v3**: https://localhost:443/api/v3/
-- **API v5**: https://localhost:443/api/v5/remote/
+- **API v3**: http://localhost:5000/api/v3/
+- **API v5**: http://localhost:5000/api/v5/remote/
 
 ## 📋 Dependencies
 

--- a/enhanced_node/readme_file_full.md
+++ b/enhanced_node/readme_file_full.md
@@ -404,7 +404,7 @@ kubectl autoscale deployment enhanced-node --cpu-percent=50 --min=2 --max=10
 ```bash
 # Core Configuration
 NODE_ENV=production
-NODE_PORT=443
+NODE_PORT=5000
 NODE_ID=enhanced-node-production-001
 
 # Database Configuration  
@@ -541,7 +541,7 @@ export PYTHONPATH=/path/to/enhanced_node:$PYTHONPATH
 **Port Conflicts**
 ```bash
 # Check port usage
-sudo netstat -tulpn | grep :443
+sudo netstat -tulpn | grep :5000
 
 # Change port in .env
 echo "NODE_PORT=5001" >> .env

--- a/ultimate_agent/readme.md
+++ b/ultimate_agent/readme.md
@@ -141,7 +141,7 @@ curl -X POST http://localhost:8080/api/start_task \
 
 ```ini
 [DEFAULT]
-node_url = https://srvnodes.peoplesainetwork.com:443
+node_url = https://srvnodes.peoplesainetwork.com
 dashboard_port = 8080
 heartbeat_interval = 30
 auto_start_tasks = true
@@ -582,7 +582,7 @@ python main.py --monitor-memory
 #### **Blockchain Connection Issues**
 ```bash
 # Test network connectivity
-curl -X GET https://srvnodes.peoplesainetwork.com:443/api/health
+curl -X GET https://srvnodes.peoplesainetwork.com/api/health
 
 # Use demo mode
 python main.py --blockchain-demo-mode


### PR DESCRIPTION
## Summary
- revert node server port back to 5000
- update environment configs and docs to reference port 5000
- keep agent connection URL using HTTPS without explicit port

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd4874e508328982b36de39d5ee4e