### PR TITLE
Fix last_activity None comparison

### DIFF
--- a/ultimate_agent/network/communication/__init__.py
+++ b/ultimate_agent/network/communication/__init__.py
@@ -320,13 +320,23 @@ class NetworkManager:
                 'sent': self.connection_stats['total_bytes_sent'],
                 'received': self.connection_stats['total_bytes_received']
             },
-            'last_activity': max(
-                self.connection_stats.get('last_successful_connection', 0),
-                self.connection_stats.get('last_failed_connection', 0)
-            ) if any([
-                self.connection_stats.get('last_successful_connection'),
-                self.connection_stats.get('last_failed_connection')
-            ]) else None
+            # Determine the timestamp of the most recent network activity. Use
+            # only non-None values to avoid comparison errors when either
+            # timestamp hasn't been set yet.
+            'last_activity': (
+                max(
+                    t for t in [
+                        self.connection_stats.get('last_successful_connection'),
+                        self.connection_stats.get('last_failed_connection')
+                    ]
+                    if t is not None
+                )
+                if any([
+                    self.connection_stats.get('last_successful_connection'),
+                    self.connection_stats.get('last_failed_connection')
+                ])
+                else None
+            )
         }
     
     def optimize_connections(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- fix `last_activity` calculation in NetworkManager to handle missing timestamps
- add clarifying comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e155e3f6c8328866827a0a350f3ca