### PR TITLE
Allow data URI fonts in dashboard CSP

### DIFF
--- a/enhanced_node/nginx_config.txt
+++ b/enhanced_node/nginx_config.txt
@@ -73,7 +73,8 @@ server {
     add_header X-Content-Type-Options nosniff always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self' wss: ws:; frame-ancestors 'none';" always;
+    # Allow embedded fonts via data: URIs in addition to the CDN
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https://cdnjs.cloudflare.com data:; connect-src 'self' wss: ws:; frame-ancestors 'none';" always;
     
     # Basic settings
     client_max_body_size 50M;


### PR DESCRIPTION
## Summary
- modify `nginx_config.txt` CSP to permit embedded fonts via `data:` URIs

## Testing
- `python -m pytest tests/`
- `flake8 ultimate_agent/` *(fails: command not found)*
- `mypy ultimate_agent/` *(fails: unterminated string literal)*

------
https://chatgpt.com/codex/tasks/task_e_684e1838058883288d846cbb0f7f141e