### PR TITLE
Add local AI chat page

### DIFF
--- a/ultimate_agent/dashboard/web/routes/__init__.py
+++ b/ultimate_agent/dashboard/web/routes/__init__.py
@@ -106,6 +106,11 @@ class DashboardServer:
             """AI Chat interface"""
             return self._get_ai_chat_html()
 
+        @self.app.route('/local-ai-chat')
+        def local_ai_chat_page():
+            """Local AI chat interface"""
+            return self._get_local_ai_chat_html()
+
         # ==================== API ENDPOINTS ====================
         
         @self.app.route('/api/stats')
@@ -732,6 +737,7 @@ class DashboardServer:
                         <button class="btn" onclick="refreshStats()">🔄 Refresh Stats</button>
                         <button class="btn" onclick="openControlRoom()">🎛️ Control Room</button>
                         <button class="btn" onclick="openAIChat()">💬 AI Chat</button>
+                        <button class="btn" onclick="openLocalAIChat()">🤖 Local AI Chat</button>
                         <button class="btn" onclick="showSystemInfo()">ℹ️ System Info</button>
                     </div>
                 </div>
@@ -831,7 +837,11 @@ class DashboardServer:
                 function openAIChat() {{
                     window.open('/ai-chat', '_blank');
                 }}
-                
+
+                function openLocalAIChat() {{
+                    window.open('/local-ai-chat', '_blank');
+                }}
+
                 async function showSystemInfo() {{
                     const systemDiv = document.getElementById('systemInfo');
                     if (systemDiv.style.display === 'none') {{
@@ -1007,6 +1017,17 @@ class DashboardServer:
         """Return AI chat interface"""
         template_path = os.path.join(
             os.path.dirname(__file__), '..', 'templates', 'ai_chat_interface.html'
+        )
+        try:
+            with open(template_path, 'r', encoding='utf-8') as f:
+                return f.read()
+        except Exception as e:
+            return f"<p>Error loading template: {e}</p>"
+
+    def _get_local_ai_chat_html(self):
+        """Return Local AI chat interface"""
+        template_path = os.path.join(
+            os.path.dirname(__file__), '..', 'templates', 'ai.html'
         )
         try:
             with open(template_path, 'r', encoding='utf-8') as f:

--- a/ultimate_agent/dashboard/web/templates/ai.html
+++ b/ultimate_agent/dashboard/web/templates/ai.html
@@ -1,4 +1,3 @@
-LOCAL_AI_DASHBOARD_HTML = """
 <!-- Add to dashboard templates -->
 <div class="local-ai-section">
     <h3>🧠 Local AI System</h3>
@@ -300,13 +299,3 @@ document.addEventListener('DOMContentLoaded', function() {
     border-radius: 5px;
 }
 </style>
-"""
-
-print("✅ Local AI integration components created!")
-print("\n🔧 Integration Steps:")
-print("1. Add Local AI routes to your dashboard")
-print("2. Update your main agent class with the integration decorator")
-print("3. Add Local AI configuration to your config file")
-print("4. Update your dashboard HTML with Local AI section")
-print("5. Install Ollama: https://ollama.ai/download")
-print("6. Install Python package: pip install ollama")


### PR DESCRIPTION
## Summary
- convert `ai.html` from Python snippet to HTML
- add `/local-ai-chat` route to dashboard
- expose new button and JS function for local AI chat

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685109ba63b88328ad1e121c09ae2e18