### PR TITLE
Make local AI initialization configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ log_level = INFO
 performance_tracking = true
 ```
 
+The `[LOCAL_AI]` section controls on-device model usage. To avoid automatic
+model downloads in offline environments, set `preload_models = false` and
+`auto_pull_models = false` under `[OLLAMA]`.
+
 ### **Command Line Options**
 
 ```bash

--- a/ultimate_agent/ai/local_models/local_ai_manager.py
+++ b/ultimate_agent/ai/local_models/local_ai_manager.py
@@ -413,7 +413,7 @@ class LocalAIManager:
         self.loaded_models: Dict[str, QuantizedModel] = {}
         self.model_catalog = get_quantized_model_catalog()
         self.current_model: Optional[QuantizedModel] = None
-        
+
         # Performance tracking
         self.inference_stats = {
             'total_requests': 0,
@@ -421,12 +421,23 @@ class LocalAIManager:
             'avg_response_time': 0.0,
             'tokens_per_second': 0.0
         }
-        
-        # Configuration
+
+        # Configuration defaults
         self.max_concurrent_requests = 3
         self.auto_model_management = True
         self.preload_models = True
-        
+
+        if self.config:
+            self.auto_model_management = self.config.getboolean(
+                'LOCAL_AI', 'auto_model_management', fallback=True
+            )
+            self.preload_models = self.config.getboolean(
+                'LOCAL_AI', 'preload_models', fallback=True
+            )
+            self.max_concurrent_requests = self.config.getint(
+                'LOCAL_AI', 'max_concurrent_requests', fallback=3
+            )
+
         self._initialize()
     
     def _initialize(self):
@@ -466,7 +477,12 @@ class LocalAIManager:
                         if loop and loop.is_running():
                             loop.create_task(self._download_model_async(optimal_model))
                         else:
-                            asyncio.run(self._download_model_async(optimal_model))
+                            threading.Thread(
+                                target=lambda: asyncio.run(
+                                    self._download_model_async(optimal_model)
+                                ),
+                                daemon=True,
+                            ).start()
             else:
                 logging.warning("⚠️ No suitable model found for this hardware")
                 

--- a/ultimate_agent/config/config_settings.py
+++ b/ultimate_agent/config/config_settings.py
@@ -108,13 +108,33 @@ class ConfigManager:
             'websocket_enabled': 'true',
             'static_files_enabled': 'true'
         }
-        
+
         # Plugin settings
         self.config['PLUGINS'] = {
             'enabled': 'true',
             'plugin_directory': './plugins',
             'auto_load': 'true',
             'sandbox_enabled': 'true'
+        }
+
+        # Local AI settings
+        self.config['LOCAL_AI'] = {
+            'enabled': 'true',
+            'auto_model_management': 'true',
+            'preload_models': 'false',
+            'prefer_local_ai': 'true',
+            'fallback_to_cloud': 'true',
+            'max_concurrent_requests': '3'
+        }
+
+        # Ollama settings
+        self.config['OLLAMA'] = {
+            'host': 'localhost',
+            'port': '11434',
+            'timeout': '30.0',
+            'auto_pull_models': 'false',
+            'model_selection_strategy': 'auto',
+            'default_model': 'auto'
         }
     
     def _save_config(self):

--- a/ultimate_agent/config/ultimate_agent_config.ini
+++ b/ultimate_agent/config/ultimate_agent_config.ini
@@ -102,7 +102,7 @@ sandbox_enabled = true
 [LOCAL_AI]
 enabled = true
 auto_model_management = true
-preload_models = true
+preload_models = false
 prefer_local_ai = true
 fallback_to_cloud = true
 max_concurrent_requests = 3
@@ -111,7 +111,7 @@ max_concurrent_requests = 3
 host = localhost
 port = 11434
 timeout = 30.0
-auto_pull_models = true
+auto_pull_models = false
 model_selection_strategy = auto
 default_model = auto
 

--- a/ultimate_agent/core/agent.py
+++ b/ultimate_agent/core/agent.py
@@ -308,6 +308,13 @@ class UltimatePainNetworkAgent(UltimateAgent):
             self.local_ai_conversation_manager = None
             return
 
+        # Check configuration to see if local AI is enabled
+        if self.config_manager and not self.config_manager.getboolean('LOCAL_AI', 'enabled', fallback=True):
+            print("⚠️ Local AI disabled in configuration")
+            self.local_ai_manager = None
+            self.local_ai_conversation_manager = None
+            return
+
         try:
             print("🧠 Initializing Local AI...")
             self.local_ai_manager = create_local_ai_manager(self.config_manager)


### PR DESCRIPTION
## Summary
- configure LocalAIManager with values from the config manager
- allow disabling the local AI in `UltimatePainNetworkAgent`
- include Local AI defaults in generated config
- default to not preloading models or auto pulling models
- document how to disable model downloads
- download models in a background thread when no event loop exists

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851109bd68483288d6880641ef1266d